### PR TITLE
[fix] Do not deny sns:GetSubscriptionAttributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/fix-role.cf.template
+++ b/fix-role.cf.template
@@ -91,7 +91,6 @@ Resources:
             - s3:GetObjectVersion
             - sdb:Select*
             - secretsmanager:GetSecretValue
-            - sns:GetSubscriptionAttributes
             - sqs:ReceiveMessage
             - ssm:GetParameter
             - ssm:GetParameters


### PR DESCRIPTION
# Description

Fix is calling sns:GetSubscriptionAttributes - do not deny.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://fix.security/code-of-conduct).
